### PR TITLE
Fix unused parameter warning in HPX transform test

### DIFF
--- a/thrust/testing/hpx/transform.cu
+++ b/thrust/testing/hpx/transform.cu
@@ -14,7 +14,7 @@ void TestTransform(ExecutionPolicy exec)
     Vector output(3);
     Vector result{-1, 2, -3};
 
-    typename Vector::iterator iter = thrust::transform(input.begin(), input.end(), output.begin(), thrust::negate<T>());
+    typename Vector::iterator iter = thrust::transform(exec, input.begin(), input.end(), output.begin(), thrust::negate<T>());
 
     ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
     ASSERT_EQUAL(output, result);
@@ -26,7 +26,7 @@ void TestTransform(ExecutionPolicy exec)
     Vector result{5, -7, -3};
 
     typename Vector::iterator iter =
-      thrust::transform(input1.begin(), input1.end(), input2.begin(), output.begin(), thrust::minus<T>());
+      thrust::transform(exec, input1.begin(), input1.end(), input2.begin(), output.begin(), thrust::minus<T>());
 
     ASSERT_EQUAL(std::size_t(iter - output.begin()), input1.size());
     ASSERT_EQUAL(output, result);


### PR DESCRIPTION
Fix unused parameter warning in HPX transform test

Error:

```
In file included from /home/weile/src/cccl/build/thrust/testing/hpx/hpx/transform.cu.cpp:1:
/home/weile/src/cccl/thrust/testing/hpx/../hpx/transform.cu: In instantiation of ‘void TestTransform(ExecutionPolicy) [with ExecutionPolicy = thrust::system::hpx::detail::parallel_policy_shim<hpx::execution::parallel_policy_executor<hpx::launch>, hpx::execution::experimental::default_parameters>]’:
/home/weile/src/cccl/thrust/testing/hpx/../hpx/transform.cu:38:16:   required from here
/home/weile/src/cccl/thrust/testing/hpx/../hpx/transform.cu:7:36: error: unused parameter ‘exec’ [-Werror=unused-parameter]
    7 | void TestTransform(ExecutionPolicy exec)
      |                    ~~~~~~~~~~~~~~~~^~~~
/home/weile/src/cccl/thrust/testing/hpx/../hpx/transform.cu: In instantiation of ‘void TestTransform(ExecutionPolicy) [with ExecutionPolicy = thrust::system::hpx::detail::parallel_policy_shim<hpx::execution::sequenced_executor, hpx::execution::experimental::default_parameters>]’:
/home/weile/src/cccl/thrust/testing/hpx/../hpx/transform.cu:46:16:   required from here
/home/weile/src/cccl/thrust/testing/hpx/../hpx/transform.cu:7:36: error: unused parameter ‘exec’ [-Werror=unused-parameter]
```
